### PR TITLE
Fix keyid in output.py to match similar functions

### DIFF
--- a/pyGPG/output.py
+++ b/pyGPG/output.py
@@ -109,7 +109,7 @@ class GPGResult(object):
         data = self.get_data(fields)
         results = []
         for item in data:
-            if item[2] is not '':
+            if item[2]:
                 results.append(item)
         if not results:
             return self.fingerprint


### PR DESCRIPTION
Fixes warning issued by python interpreter about  `is not ''`